### PR TITLE
Remove raw mode from SVG editor

### DIFF
--- a/app/editor/svg-editor.tsx
+++ b/app/editor/svg-editor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState } from "react";
 
 type RectShape = {
   id: number;
@@ -30,18 +30,10 @@ export function SvgEditor() {
   const [color, setColor] = useState("#3b82f6");
   const [history, setHistory] = useState<Shape[][]>([]);
   const [future, setFuture] = useState<Shape[][]>([]);
-  const [mode, setMode] = useState<"blocks" | "raw">("blocks");
-  const [svgCode, setSvgCode] = useState("");
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [elementCode, setElementCode] = useState("");
   const svgRef = useRef<SVGSVGElement>(null);
   const idRef = useRef(0);
-
-  useEffect(() => {
-    if (mode === "raw") {
-      setSvgCode(generateSvg(shapes));
-    }
-  }, [mode, shapes]);
 
   function hexToRgba(hex: string, alpha: number) {
     const trimmed = hex.replace("#", "");
@@ -64,17 +56,6 @@ export function SvgEditor() {
     };
   }
 
-  function toggleMode() {
-    if (mode === "blocks") {
-      setSvgCode(generateSvg(shapes));
-      setMode("raw");
-    } else {
-      parseSvg(svgCode);
-      setSelectedId(null);
-      setMode("blocks");
-    }
-  }
-
   function generateSvg(list: Shape[]) {
     const elements = list
       .map((s) => {
@@ -93,47 +74,6 @@ export function SvgEditor() {
     return `<svg xmlns="http://www.w3.org/2000/svg">\n  ${elements}\n</svg>`;
   }
 
-  function parseSvg(code: string) {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(code, "image/svg+xml");
-    const newShapes: Shape[] = [];
-    idRef.current = 0;
-    doc.querySelectorAll("rect").forEach((el) => {
-      const x = parseFloat(el.getAttribute("x") || "0");
-      const y = parseFloat(el.getAttribute("y") || "0");
-      const width = parseFloat(el.getAttribute("width") || "0");
-      const height = parseFloat(el.getAttribute("height") || "0");
-      const fill = el.getAttribute("fill") || "transparent";
-      const stroke = el.getAttribute("stroke") || "black";
-      newShapes.push({
-        id: idRef.current++,
-        type: "rect",
-        x,
-        y,
-        width,
-        height,
-        fill,
-        stroke,
-      });
-    });
-    doc.querySelectorAll("circle").forEach((el) => {
-      const cx = parseFloat(el.getAttribute("cx") || "0");
-      const cy = parseFloat(el.getAttribute("cy") || "0");
-      const r = parseFloat(el.getAttribute("r") || "0");
-      const fill = el.getAttribute("fill") || "transparent";
-      const stroke = el.getAttribute("stroke") || "black";
-      newShapes.push({
-        id: idRef.current++,
-        type: "circle",
-        cx,
-        cy,
-        r,
-        fill,
-        stroke,
-      });
-    });
-    setShapes(newShapes);
-  }
 
   function onMouseDown(e: React.MouseEvent<SVGSVGElement>) {
     const { x, y } = getRelativePoint(e);
@@ -234,176 +174,152 @@ export function SvgEditor() {
 
   return (
     <div className="fixed inset-0">
-      {mode === "blocks" ? (
-        <>
-          <svg
-            ref={svgRef}
-            className="block w-full h-full bg-white dark:bg-gray-900"
-            onMouseDown={onMouseDown}
-            onMouseMove={onMouseMove}
-            onMouseUp={onMouseUp}
+      <svg
+        ref={svgRef}
+        className="block w-full h-full bg-white dark:bg-gray-900"
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+      >
+        <defs>
+          <pattern id="small-grid" width="20" height="20" patternUnits="userSpaceOnUse">
+            <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#e5e7eb" strokeWidth="0.5" />
+          </pattern>
+          <pattern id="grid" width="100" height="100" patternUnits="userSpaceOnUse">
+            <rect width="100" height="100" fill="url(#small-grid)" />
+            <path d="M 100 0 L 0 0 0 100" fill="none" stroke="#d1d5db" strokeWidth="1" />
+          </pattern>
+        </defs>
+        <rect width="100%" height="100%" fill="url(#grid)" />
+        {shapes.map((shape) => (
+          shape.type === "rect" ? (
+            <rect
+              key={shape.id}
+              x={Math.min(shape.x, shape.x + shape.width)}
+              y={Math.min(shape.y, shape.y + shape.height)}
+              width={Math.abs(shape.width)}
+              height={Math.abs(shape.height)}
+              fill={shape.fill}
+              stroke={shape.stroke}
+              onClick={() => {
+                setSelectedId(shape.id);
+                setElementCode(generateSvg([shape]).split("\n")[1].trim());
+              }}
+            />
+          ) : (
+            <circle
+              key={shape.id}
+              cx={shape.cx}
+              cy={shape.cy}
+              r={Math.abs(shape.r)}
+              fill={shape.fill}
+              stroke={shape.stroke}
+              onClick={() => {
+                setSelectedId(shape.id);
+                setElementCode(generateSvg([shape]).split("\n")[1].trim());
+              }}
+            />
+          )
+        ))}
+      </svg>
+
+      <div className="absolute top-4 left-4 z-10 flex flex-col gap-2 p-4 bg-white/90 dark:bg-gray-800/90 rounded shadow text-gray-800 dark:text-gray-100">
+        <h1 className="text-lg font-semibold">SVG Editor</h1>
+        <label className="flex flex-col text-sm gap-1">
+          <span>Shape</span>
+          <select
+            className="border rounded px-2 py-1 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border-gray-300 dark:border-gray-600"
+            value={shapeType}
+            onChange={(e) => setShapeType(e.target.value as "rect" | "circle")}
           >
-            <defs>
-              <pattern id="small-grid" width="20" height="20" patternUnits="userSpaceOnUse">
-                <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#e5e7eb" strokeWidth="0.5" />
-              </pattern>
-              <pattern id="grid" width="100" height="100" patternUnits="userSpaceOnUse">
-                <rect width="100" height="100" fill="url(#small-grid)" />
-                <path d="M 100 0 L 0 0 0 100" fill="none" stroke="#d1d5db" strokeWidth="1" />
-              </pattern>
-            </defs>
-            <rect width="100%" height="100%" fill="url(#grid)" />
-            {shapes.map((shape) => (
-              shape.type === "rect" ? (
-                <rect
-                  key={shape.id}
-                  x={Math.min(shape.x, shape.x + shape.width)}
-                  y={Math.min(shape.y, shape.y + shape.height)}
-                  width={Math.abs(shape.width)}
-                  height={Math.abs(shape.height)}
-                  fill={shape.fill}
-                  stroke={shape.stroke}
-                  onClick={() => {
-                    setSelectedId(shape.id);
-                    setElementCode(generateSvg([shape]).split("\n")[1].trim());
-                  }}
-                />
-              ) : (
-                <circle
-                  key={shape.id}
-                  cx={shape.cx}
-                  cy={shape.cy}
-                  r={Math.abs(shape.r)}
-                  fill={shape.fill}
-                  stroke={shape.stroke}
-                  onClick={() => {
-                    setSelectedId(shape.id);
-                    setElementCode(generateSvg([shape]).split("\n")[1].trim());
-                  }}
-                />
-              )
-            ))}
-          </svg>
+            <option value="rect">Rectangle</option>
+            <option value="circle">Circle</option>
+          </select>
+        </label>
+        <label className="flex flex-col text-sm gap-1">
+          <span>Color</span>
+          <input
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+            className="h-8 w-full p-0 border rounded bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600"
+          />
+        </label>
+        <button
+          className="w-full px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700"
+          onClick={undo}
+          disabled={history.length === 0}
+        >
+          Undo
+        </button>
+        <button
+          className="w-full px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700"
+          onClick={redo}
+          disabled={future.length === 0}
+        >
+          Redo
+        </button>
+        <button
+          className="w-full px-3 py-1 rounded bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+          onClick={clear}
+        >
+          Clear
+        </button>
+        <button
+          className="w-full px-3 py-1 rounded bg-green-500 text-white hover:bg-green-600 dark:bg-green-600 dark:hover:bg-green-700"
+          onClick={download}
+        >
+          Download
+        </button>
+        <p className="text-xs text-gray-500 dark:text-gray-400 pt-2">Drag on the canvas to draw.</p>
+      </div>
 
-          <div className="absolute top-4 left-4 z-10 flex flex-col gap-2 p-4 bg-white/90 dark:bg-gray-800/90 rounded shadow text-gray-800 dark:text-gray-100">
-            <h1 className="text-lg font-semibold">SVG Editor</h1>
-            <button
-              className="px-2 py-1 rounded bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
-              onClick={toggleMode}
-            >
-              Raw
-            </button>
-            <label className="flex flex-col text-sm gap-1">
-              <span>Shape</span>
-              <select
-                className="border rounded px-2 py-1 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border-gray-300 dark:border-gray-600"
-                value={shapeType}
-                onChange={(e) => setShapeType(e.target.value as "rect" | "circle")}
-              >
-                <option value="rect">Rectangle</option>
-                <option value="circle">Circle</option>
-              </select>
-            </label>
-            <label className="flex flex-col text-sm gap-1">
-              <span>Color</span>
-              <input
-                type="color"
-                value={color}
-                onChange={(e) => setColor(e.target.value)}
-                className="h-8 w-full p-0 border rounded bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600"
-              />
-            </label>
-            <button
-              className="w-full px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700"
-              onClick={undo}
-              disabled={history.length === 0}
-            >
-              Undo
-            </button>
-            <button
-              className="w-full px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700"
-              onClick={redo}
-              disabled={future.length === 0}
-            >
-              Redo
-            </button>
-            <button
-              className="w-full px-3 py-1 rounded bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
-              onClick={clear}
-            >
-              Clear
-            </button>
-            <button
-              className="w-full px-3 py-1 rounded bg-green-500 text-white hover:bg-green-600 dark:bg-green-600 dark:hover:bg-green-700"
-              onClick={download}
-            >
-              Download
-            </button>
-            <p className="text-xs text-gray-500 dark:text-gray-400 pt-2">Drag on the canvas to draw.</p>
-          </div>
-
-          {selectedId !== null && (
-            <div className="absolute top-4 right-4 z-10 p-4 bg-white/90 dark:bg-gray-800/90 rounded shadow flex flex-col gap-2 text-gray-800 dark:text-gray-100">
-              <textarea
-                className="w-64 h-32 font-mono text-sm p-2 border rounded bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600"
-                value={elementCode}
-                onChange={(e) => {
-                  const code = `<svg xmlns=\"http://www.w3.org/2000/svg\">${e.target.value}</svg>`;
-                  const parser = new DOMParser();
-                  const doc = parser.parseFromString(code, "image/svg+xml");
-                  const el = doc.firstElementChild?.firstElementChild as SVGElement | null;
-                  if (!el) return;
-                  setElementCode(e.target.value);
-                  setShapes((prev) =>
-                    prev.map((s) => {
-                      if (s.id !== selectedId) return s;
-                      if (el.tagName === "rect") {
-                        return {
-                          id: s.id,
-                          type: "rect",
-                          x: parseFloat(el.getAttribute("x") || "0"),
-                          y: parseFloat(el.getAttribute("y") || "0"),
-                          width: parseFloat(el.getAttribute("width") || "0"),
-                          height: parseFloat(el.getAttribute("height") || "0"),
-                          fill: el.getAttribute("fill") || "transparent",
-                          stroke: el.getAttribute("stroke") || "black",
-                        };
-                      } else {
-                        return {
-                          id: s.id,
-                          type: "circle",
-                          cx: parseFloat(el.getAttribute("cx") || "0"),
-                          cy: parseFloat(el.getAttribute("cy") || "0"),
-                          r: parseFloat(el.getAttribute("r") || "0"),
-                          fill: el.getAttribute("fill") || "transparent",
-                          stroke: el.getAttribute("stroke") || "black",
-                        };
-                      }
-                    })
-                  );
-                }}
-              />
-              <button
-                className="px-2 py-1 rounded bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
-                onClick={() => setSelectedId(null)}
-              >
-                Close
-              </button>
-            </div>
-          )}
-        </>
-      ) : (
-        <div className="w-full h-full relative">
+      {selectedId !== null && (
+        <div className="absolute top-4 right-4 z-10 p-4 bg-white/90 dark:bg-gray-800/90 rounded shadow flex flex-col gap-2 text-gray-800 dark:text-gray-100">
           <textarea
-            className="w-full h-full p-4 font-mono text-sm bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100"
-            value={svgCode}
-            onChange={(e) => setSvgCode(e.target.value)}
+            className="w-64 h-32 font-mono text-sm p-2 border rounded bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600"
+            value={elementCode}
+            onChange={(e) => {
+              const code = `<svg xmlns=\"http://www.w3.org/2000/svg\">${e.target.value}</svg>`;
+              const parser = new DOMParser();
+              const doc = parser.parseFromString(code, "image/svg+xml");
+              const el = doc.firstElementChild?.firstElementChild as SVGElement | null;
+              if (!el) return;
+              setElementCode(e.target.value);
+              setShapes((prev) =>
+                prev.map((s) => {
+                  if (s.id !== selectedId) return s;
+                  if (el.tagName === "rect") {
+                    return {
+                      id: s.id,
+                      type: "rect",
+                      x: parseFloat(el.getAttribute("x") || "0"),
+                      y: parseFloat(el.getAttribute("y") || "0"),
+                      width: parseFloat(el.getAttribute("width") || "0"),
+                      height: parseFloat(el.getAttribute("height") || "0"),
+                      fill: el.getAttribute("fill") || "transparent",
+                      stroke: el.getAttribute("stroke") || "black",
+                    };
+                  } else {
+                    return {
+                      id: s.id,
+                      type: "circle",
+                      cx: parseFloat(el.getAttribute("cx") || "0"),
+                      cy: parseFloat(el.getAttribute("cy") || "0"),
+                      r: parseFloat(el.getAttribute("r") || "0"),
+                      fill: el.getAttribute("fill") || "transparent",
+                      stroke: el.getAttribute("stroke") || "black",
+                    };
+                  }
+                })
+              );
+            }}
           />
           <button
-            className="absolute top-4 left-4 px-2 py-1 rounded bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
-            onClick={toggleMode}
+            className="px-2 py-1 rounded bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+            onClick={() => setSelectedId(null)}
           >
-            Blocks
+            Close
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
- simplify SVG editor to always show block-based interface
- drop raw SVG mode and related toggle

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba266fa788327b7bc3c7d1f2bdb81