### PR TITLE
feat: add movable blocks with per-element tools

### DIFF
--- a/app/editor/svg-editor.tsx
+++ b/app/editor/svg-editor.tsx
@@ -31,48 +31,23 @@ export function SvgEditor() {
   const [history, setHistory] = useState<Shape[][]>([]);
   const [future, setFuture] = useState<Shape[][]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
-  const [elementCode, setElementCode] = useState("");
+  const [draggingId, setDraggingId] = useState<number | null>(null);
+  const dragOffset = useRef<{ x: number; y: number } | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const idRef = useRef(0);
-
-  function hexToRgba(hex: string, alpha: number) {
-    const trimmed = hex.replace("#", "");
-    const bigint = parseInt(trimmed, 16);
-    const r = (bigint >> 16) & 255;
-    const g = (bigint >> 8) & 255;
-    const b = bigint & 255;
-    return `rgba(${r},${g},${b},${alpha})`;
-  }
+  const selectedShape = shapes.find((s) => s.id === selectedId);
 
   function snapshot(list: Shape[]) {
     return list.map((s) => ({ ...s }));
   }
 
-  function getRelativePoint(e: React.MouseEvent<SVGSVGElement>) {
+  function getRelativePoint(e: React.MouseEvent<SVGElement>) {
     const rect = svgRef.current!.getBoundingClientRect();
     return {
       x: e.clientX - rect.left,
       y: e.clientY - rect.top,
     };
-  }
-
-  function generateSvg(list: Shape[]) {
-    const elements = list
-      .map((s) => {
-        if (s.type === "rect") {
-          const x = Math.min(s.x, s.x + s.width);
-          const y = Math.min(s.y, s.y + s.height);
-          const width = Math.abs(s.width);
-          const height = Math.abs(s.height);
-          return `<rect x="${x}" y="${y}" width="${width}" height="${height}" fill="${s.fill}" stroke="${s.stroke}" />`;
-        } else {
-          const r = Math.abs(s.r);
-          return `<circle cx="${s.cx}" cy="${s.cy}" r="${r}" fill="${s.fill}" stroke="${s.stroke}" />`;
-        }
-      })
-      .join("\n  ");
-    return `<svg xmlns="http://www.w3.org/2000/svg">\n  ${elements}\n</svg>`;
   }
 
   function handleFile(file: File) {
@@ -137,7 +112,7 @@ export function SvgEditor() {
         y,
         width: 0,
         height: 0,
-        fill: hexToRgba(color, 0.3),
+        fill: color,
         stroke: color,
       };
     } else {
@@ -147,7 +122,7 @@ export function SvgEditor() {
         cx: x,
         cy: y,
         r: 0,
-        fill: hexToRgba(color, 0.3),
+        fill: color,
         stroke: color,
       };
     }
@@ -155,7 +130,36 @@ export function SvgEditor() {
     setShapes((prev) => [...prev, newShape]);
   }
 
+  function onShapeMouseDown(e: React.MouseEvent<SVGElement>, shape: Shape) {
+    e.stopPropagation();
+    const { x, y } = getRelativePoint(e);
+    setSelectedId(shape.id);
+    setHistory((prev) => [...prev, snapshot(shapes)]);
+    setFuture([]);
+    if (shape.type === "rect") {
+      dragOffset.current = { x: x - shape.x, y: y - shape.y };
+    } else {
+      dragOffset.current = { x: x - shape.cx, y: y - shape.cy };
+    }
+    setDraggingId(shape.id);
+  }
+
   function onMouseMove(e: React.MouseEvent<SVGSVGElement>) {
+    if (draggingId !== null) {
+      const { x, y } = getRelativePoint(e);
+      setShapes((prev) =>
+        prev.map((s) => {
+          if (s.id !== draggingId) return s;
+          const offset = dragOffset.current!;
+          if (s.type === "rect") {
+            return { ...s, x: x - offset.x, y: y - offset.y };
+          } else {
+            return { ...s, cx: x - offset.x, cy: y - offset.y };
+          }
+        })
+      );
+      return;
+    }
     if (!drawing) return;
     const { x, y } = getRelativePoint(e);
     let updated: Shape;
@@ -177,7 +181,27 @@ export function SvgEditor() {
   }
 
   function onMouseUp() {
+    if (drawing) {
+      if (drawing.type === "rect") {
+        const x = Math.min(drawing.x, drawing.x + drawing.width);
+        const y = Math.min(drawing.y, drawing.y + drawing.height);
+        const width = Math.abs(drawing.width);
+        const height = Math.abs(drawing.height);
+        setShapes((prev) =>
+          prev.map((s) =>
+            s.id === drawing.id ? { ...drawing, x, y, width, height } : s
+          )
+        );
+      } else {
+        const r = Math.abs(drawing.r);
+        setShapes((prev) =>
+          prev.map((s) => (s.id === drawing.id ? { ...drawing, r } : s))
+        );
+      }
+    }
     setDrawing(null);
+    setDraggingId(null);
+    dragOffset.current = null;
   }
 
   function clear() {
@@ -223,13 +247,13 @@ export function SvgEditor() {
 
   return (
     <div
-      className="fixed inset-0 flex"
+      className="fixed inset-0 flex flex-col"
       onDragOver={onDragOver}
       onDrop={onDrop}
     >
-      <div className="w-64 p-4 bg-white/90 dark:bg-gray-800/90 text-gray-800 dark:text-gray-100 flex flex-col gap-2 z-10">
+      <div className="p-4 bg-white/90 dark:bg-gray-800/90 text-gray-800 dark:text-gray-100 flex items-center gap-2 flex-wrap z-10">
         <h1 className="text-lg font-semibold">SVG Editor</h1>
-        <label className="flex flex-col text-sm gap-1">
+        <label className="flex items-center text-sm gap-1">
           <span>Shape</span>
           <select
             className="border rounded px-2 py-1 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border-gray-300 dark:border-gray-600"
@@ -240,160 +264,158 @@ export function SvgEditor() {
             <option value="circle">Circle</option>
           </select>
         </label>
-        <label className="flex flex-col text-sm gap-1">
+        <label className="flex items-center text-sm gap-1">
           <span>Color</span>
           <input
             type="color"
             value={color}
             onChange={(e) => setColor(e.target.value)}
-            className="h-8 w-full p-0 border rounded bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600"
+            className="h-8 w-8 p-0 border rounded bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600"
           />
         </label>
         <button
-          className="w-full px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700"
+          className="px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700"
           onClick={undo}
           disabled={history.length === 0}
         >
           Undo
         </button>
         <button
-          className="w-full px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700"
+          className="px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 dark:bg-blue-600 dark:hover:bg-blue-700"
           onClick={redo}
           disabled={future.length === 0}
         >
           Redo
         </button>
         <button
-          className="w-full px-3 py-1 rounded bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+          className="px-3 py-1 rounded bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
           onClick={clear}
         >
           Clear
         </button>
         <button
-          className="w-full px-3 py-1 rounded bg-green-500 text-white hover:bg-green-600 dark:bg-green-600 dark:hover:bg-green-700"
+          className="px-3 py-1 rounded bg-green-500 text-white hover:bg-green-600 dark:bg-green-600 dark:hover:bg-green-700"
           onClick={download}
         >
           Download
         </button>
-        <p className="text-xs text-gray-500 dark:text-gray-400 pt-2">Drag on the canvas to draw.</p>
+        <p className="text-xs text-gray-500 dark:text-gray-400 ml-auto">Drag on the canvas to draw.</p>
       </div>
 
-      <div className="flex-1 relative">
-        <svg
-          ref={svgRef}
-          className="block w-full h-full bg-white dark:bg-gray-900"
-          onMouseDown={onMouseDown}
-          onMouseMove={onMouseMove}
-          onMouseUp={onMouseUp}
-        >
-          <defs>
-            <pattern id="small-grid" width="20" height="20" patternUnits="userSpaceOnUse">
-              <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#e5e7eb" strokeWidth="0.5" />
-            </pattern>
-            <pattern id="grid" width="100" height="100" patternUnits="userSpaceOnUse">
-              <rect width="100" height="100" fill="url(#small-grid)" />
-              <path d="M 100 0 L 0 0 0 100" fill="none" stroke="#d1d5db" strokeWidth="1" />
-            </pattern>
-          </defs>
-          <rect width="100%" height="100%" fill="url(#grid)" />
-          {shapes.map((shape) => (
-            shape.type === "rect" ? (
-              <rect
-                key={shape.id}
-                x={Math.min(shape.x, shape.x + shape.width)}
-                y={Math.min(shape.y, shape.y + shape.height)}
-                width={Math.abs(shape.width)}
-                height={Math.abs(shape.height)}
-                fill={shape.fill}
-                stroke={shape.stroke}
-                onClick={() => {
-                  setSelectedId(shape.id);
-                  setElementCode(generateSvg([shape]).split("\n")[1].trim());
-                }}
-              />
-            ) : (
-              <circle
-                key={shape.id}
-                cx={shape.cx}
-                cy={shape.cy}
-                r={Math.abs(shape.r)}
-                fill={shape.fill}
-                stroke={shape.stroke}
-                onClick={() => {
-                  setSelectedId(shape.id);
-                  setElementCode(generateSvg([shape]).split("\n")[1].trim());
-                }}
-              />
-            )
-          ))}
-        </svg>
+      <div className="flex flex-1">
+        <div className="flex-1 relative">
+          <svg
+            ref={svgRef}
+            className="block w-full h-full bg-white dark:bg-gray-900"
+            onMouseDown={onMouseDown}
+            onMouseMove={onMouseMove}
+            onMouseUp={onMouseUp}
+          >
+            <defs>
+              <pattern id="small-grid" width="20" height="20" patternUnits="userSpaceOnUse">
+                <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#e5e7eb" strokeWidth="0.5" />
+              </pattern>
+              <pattern id="grid" width="100" height="100" patternUnits="userSpaceOnUse">
+                <rect width="100" height="100" fill="url(#small-grid)" />
+                <path d="M 100 0 L 0 0 0 100" fill="none" stroke="#d1d5db" strokeWidth="1" />
+              </pattern>
+            </defs>
+            <rect width="100%" height="100%" fill="url(#grid)" />
+            {shapes.map((shape) => (
+              shape.type === "rect" ? (
+                <rect
+                  key={shape.id}
+                  x={Math.min(shape.x, shape.x + shape.width)}
+                  y={Math.min(shape.y, shape.y + shape.height)}
+                  width={Math.abs(shape.width)}
+                  height={Math.abs(shape.height)}
+                  fill={shape.fill}
+                  stroke={shape.stroke}
+                  fillOpacity={0.3}
+                  className="cursor-move"
+                  onMouseDown={(e) => onShapeMouseDown(e, shape)}
+                />
+              ) : (
+                <circle
+                  key={shape.id}
+                  cx={shape.cx}
+                  cy={shape.cy}
+                  r={Math.abs(shape.r)}
+                  fill={shape.fill}
+                  stroke={shape.stroke}
+                  fillOpacity={0.3}
+                  className="cursor-move"
+                  onMouseDown={(e) => onShapeMouseDown(e, shape)}
+                />
+              )
+            ))}
+          </svg>
 
-        {shapes.length === 0 && (
-          <div className="absolute inset-0 flex items-center justify-center text-gray-500 dark:text-gray-400 pointer-events-none">
-            <div className="text-center">
-              <p className="mb-2">Drag & drop an SVG file here or</p>
-              <button
-                className="px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 pointer-events-auto"
-                onClick={() => fileInputRef.current?.click()}
-              >
-                Upload
-              </button>
+          {shapes.length === 0 && (
+            <div className="absolute inset-0 flex items-center justify-center text-gray-500 dark:text-gray-400 pointer-events-none">
+              <div className="text-center">
+                <p className="mb-2">Drag & drop an SVG file here or</p>
+                <button
+                  className="px-3 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 pointer-events-auto"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  Upload
+                </button>
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/svg+xml"
-          className="hidden"
-          onChange={(e) => {
-            const file = e.target.files?.[0];
-            if (file) handleFile(file);
-          }}
-        />
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/svg+xml"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleFile(file);
+            }}
+          />
+        </div>
 
-        {selectedId !== null && (
-          <div className="absolute top-4 right-4 z-10 p-4 bg-white/90 dark:bg-gray-800/90 rounded shadow flex flex-col gap-2 text-gray-800 dark:text-gray-100">
-            <textarea
-              className="w-64 h-32 font-mono text-sm p-2 border rounded bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600"
-              value={elementCode}
-              onChange={(e) => {
-                const code = `<svg xmlns=\"http://www.w3.org/2000/svg\">${e.target.value}</svg>`;
-                const parser = new DOMParser();
-                const doc = parser.parseFromString(code, "image/svg+xml");
-                const el = doc.firstElementChild?.firstElementChild as SVGElement | null;
-                if (!el) return;
-                setElementCode(e.target.value);
-                setShapes((prev) =>
-                  prev.map((s) => {
-                    if (s.id !== selectedId) return s;
-                    if (el.tagName === "rect") {
-                      return {
-                        id: s.id,
-                        type: "rect",
-                        x: parseFloat(el.getAttribute("x") || "0"),
-                        y: parseFloat(el.getAttribute("y") || "0"),
-                        width: parseFloat(el.getAttribute("width") || "0"),
-                        height: parseFloat(el.getAttribute("height") || "0"),
-                        fill: el.getAttribute("fill") || "transparent",
-                        stroke: el.getAttribute("stroke") || "black",
-                      };
-                    } else {
-                      return {
-                        id: s.id,
-                        type: "circle",
-                        cx: parseFloat(el.getAttribute("cx") || "0"),
-                        cy: parseFloat(el.getAttribute("cy") || "0"),
-                        r: parseFloat(el.getAttribute("r") || "0"),
-                        fill: el.getAttribute("fill") || "transparent",
-                        stroke: el.getAttribute("stroke") || "black",
-                      };
-                    }
-                  })
-                );
-              }}
-            />
+        {selectedShape && (
+          <div className="w-64 p-4 bg-white/90 dark:bg-gray-800/90 text-gray-800 dark:text-gray-100 flex flex-col gap-2 z-10">
+            <h2 className="text-md font-semibold">Shape Tools</h2>
+            <label className="flex flex-col text-sm gap-1">
+              <span>Fill</span>
+              <input
+                type="color"
+                value={selectedShape.fill.startsWith("#") ? selectedShape.fill : "#000000"}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setHistory((prev) => [...prev, snapshot(shapes)]);
+                  setFuture([]);
+                  setShapes((prev) =>
+                    prev.map((s) =>
+                      s.id === selectedShape.id ? { ...s, fill: value } : s
+                    )
+                  );
+                }}
+                className="h-8 w-full p-0 border rounded bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600"
+              />
+            </label>
+            <label className="flex flex-col text-sm gap-1">
+              <span>Stroke</span>
+              <input
+                type="color"
+                value={selectedShape.stroke.startsWith("#") ? selectedShape.stroke : "#000000"}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  setHistory((prev) => [...prev, snapshot(shapes)]);
+                  setFuture([]);
+                  setShapes((prev) =>
+                    prev.map((s) =>
+                      s.id === selectedShape.id ? { ...s, stroke: value } : s
+                    )
+                  );
+                }}
+                className="h-8 w-full p-0 border rounded bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600"
+              />
+            </label>
             <button
               className="px-2 py-1 rounded bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
               onClick={() => setSelectedId(null)}


### PR DESCRIPTION
## Summary
- restructure editor layout with top toolbar and right-side shape inspector
- enable dragging SVG blocks directly on the canvas
- allow per-shape fill and stroke color editing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689bd1dca10483279fbd3a3c53bab34e