### PR TITLE
Handle SVG files without MIME type

### DIFF
--- a/app/editor/svg-editor.tsx
+++ b/app/editor/svg-editor.tsx
@@ -300,8 +300,12 @@ export function SvgEditor() {
   function onDrop(e: React.DragEvent<HTMLDivElement>) {
     e.preventDefault();
     const file = e.dataTransfer.files[0];
-    if (file && file.type === "image/svg+xml") {
-      handleFile(file);
+    if (file) {
+      const isSvg =
+        file.type === "image/svg+xml" || file.name.toLowerCase().endsWith(".svg");
+      if (isSvg) {
+        handleFile(file);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Allow drag-and-drop uploads for SVG files that lack a MIME type by checking file extension

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cb6725e008327819058469fe67bce